### PR TITLE
fix: use previous election security warning filtering

### DIFF
--- a/scripts/runner-no-security-warnings.sh
+++ b/scripts/runner-no-security-warnings.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-"$DRAWIO_DESKTOP_EXECUTABLE_PATH" "$@" --no-sandbox 2>&1

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -2,14 +2,7 @@
 set -e
 
 if [ "${ELECTRON_DISABLE_SECURITY_WARNINGS}" == "true" ]; then
-  "$DRAWIO_DESKTOP_EXECUTABLE_PATH" "$@" --no-sandbox 3>&1 >&2 2>&3 3>&- |
-    grep -v "Failed to connect to socket" |
-    grep -v "Could not parse server address" |
-    grep -v "Floss manager not present" |
-    grep -v "Exiting GPU process" |
-    grep -v "called with multiple threads" |
-    grep -v "extension not supported" |
-    grep -v "Failed to send GpuControl.CreateCommandBuffer"
+  "$DRAWIO_DESKTOP_EXECUTABLE_PATH" "$@" --no-sandbox 2> >(grep -v "Failed to connect to socket\|Could not parse server address\|Floss manager not present\|Exiting GPU process\|called with multiple threads\|extension not supported\|Failed to send GpuControl.CreateCommandBuffer")
 else
   "$DRAWIO_DESKTOP_EXECUTABLE_PATH" "$@" --no-sandbox 2>&1
 fi


### PR DESCRIPTION
The `swap file descriptor method` fail to work on GitLab CI or Azure Devops for example but works on GitHub Actions. 
Revert to using the old version with some rewrite to avoid the issue.