### PR TITLE
fix: use previous election security warning filtering

### DIFF
--- a/.github/workflows/docker-drawio-desktop-headless.yaml
+++ b/.github/workflows/docker-drawio-desktop-headless.yaml
@@ -24,6 +24,13 @@ jobs:
         env:
           DOCKER_IMAGE: ${{ github.repository }}:${{ env.GITHUB_REF_SLUG }}
 
+      - name: Test docker image // Store output logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-docker-image-logs
+          path: "tests/output/*.log"
+        if: ${{ failure() }}
+
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -e; \
   wget -q https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-amd64-${DRAWIO_VERSION}.deb \
   && apt-get install -y /opt/drawio-desktop/drawio-amd64-${DRAWIO_VERSION}.deb \
   && rm -rf /opt/drawio-desktop/drawio-amd64-${DRAWIO_VERSION}.deb; \
+  apt-get remove -y wget; \
   rm -rf /var/lib/apt/lists/*;
 
 COPY scripts/* ./

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Start Xvfb
 export DISPLAY="${XVFB_DISPLAY}"

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -9,7 +9,8 @@ if [ "${ELECTRON_DISABLE_SECURITY_WARNINGS}" == "true" ]; then
     grep -v "Exiting GPU process" |
     grep -v "called with multiple threads" |
     grep -v "extension not supported" |
-    grep -v "Failed to send GpuControl.CreateCommandBuffer"
+    grep -v "Failed to send GpuControl.CreateCommandBuffer" |
+    grep -v "Init observer found at shutdown"
 else
   "$DRAWIO_DESKTOP_EXECUTABLE_PATH" "$@" --no-sandbox 2>&1
 fi

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 if [ "${ELECTRON_DISABLE_SECURITY_WARNINGS}" == "true" ]; then
-  "$DRAWIO_DESKTOP_EXECUTABLE_PATH" "$@" --no-sandbox 3>&1 >&2 2>&3 3>&- |
+  "$DRAWIO_DESKTOP_EXECUTABLE_PATH" "$@" --no-sandbox 2>&1 |
     grep -v "Failed to connect to socket" |
     grep -v "Could not parse server address" |
     grep -v "Floss manager not present" |

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -11,10 +11,11 @@ docker_test() {
   shift
   run docker container run -t $docker_opts -w /data -v $(pwd)/${data_folder:-}:/data ${DOCKER_IMAGE} "$@"
 
-  echo "$output" > "tests/output/$output_file.log"
+  # Remove timed logging tags on electron logs by default.
+  echo "$output" | sed 's#\[.*:.*/.*\..*:.*:.*\(.*\)\] ##' >"tests/output/$output_file.log"
 
   [ "$status" -eq $status ]
   if [ -f "tests/expected/$output_file.log" ]; then
-    [ "$(diff --strip-trailing-cr <(echo "$output") "tests/expected/$output_file.log")" = "" ]
+    [ "$(diff --strip-trailing-cr "tests/output/$output_file.log" "tests/expected/$output_file.log")" = "" ]
   fi
 }

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -12,10 +12,10 @@ docker_test() {
   run docker container run -t $docker_opts -w /data -v $(pwd)/${data_folder:-}:/data ${DOCKER_IMAGE} "$@"
 
   # Remove timed logging tags on electron logs by default.
-  echo "$output" | sed 's#\[.*:.*/.*\..*:.*:.*\(.*\)\] ##' >"tests/output/$output_file.log"
+  echo "$output" | tee "tests/output/$output_file.log" | sed 's#\[.*:.*/.*\..*:.*:.*\(.*\)\] ##' >"tests/output/$output_file-comp.log"
 
   [ "$status" -eq $status ]
   if [ -f "tests/expected/$output_file.log" ]; then
-    [ "$(diff --strip-trailing-cr "tests/output/$output_file.log" "tests/expected/$output_file.log")" = "" ]
+    [ "$(diff --strip-trailing-cr "tests/output/$output_file-comp.log" "tests/expected/$output_file.log")" = "" ]
   fi
 }

--- a/tests/expected/output-electron-security-warning.log
+++ b/tests/expected/output-electron-security-warning.log
@@ -1,0 +1,12 @@
+Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+Floss manager not present, cannot set Floss enable/disable.
+Exiting GPU process due to errors during initialization
+InitializeSandbox() called with multiple threads in process gpu-process.
+dri3 extension not supported.
+ContextResult::kTransientFailure: Failed to send GpuControl.CreateCommandBuffer.
+file1.drawio -> file1.pdf

--- a/tests/output.bats
+++ b/tests/output.bats
@@ -6,6 +6,6 @@
   docker_test "" 1 "output-unknown-file" "tests/data" -x unknown.drawio
 }
 
-#@test "Output electron security warning" {
-#  docker_test "-e ELECTRON_DISABLE_SECURITY_WARNINGS=false" 0 "output-electron-security-warning" "tests/data" -x file1.drawio
-#}
+@test "Output electron security warning" {
+  docker_test "-e ELECTRON_DISABLE_SECURITY_WARNINGS=false" 0 "output-electron-security-warning" "tests/data" -x file1.drawio
+}


### PR DESCRIPTION
The swap file descriptor method fail to work on GitLab CI or Azure Devops for example but works on GitHub Actions. Revert to using the previous method to avoid the issue.