### PR TITLE
ci(autoupdate): enable workflow trigger on pull request

### DIFF
--- a/.github/workflows/dependencies-autoupdate.yaml
+++ b/.github/workflows/dependencies-autoupdate.yaml
@@ -23,3 +23,4 @@ jobs:
           title: "feat: bump dependencies"
           branch: dependencies-autoupdate
           reviewers: rlespinasse
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
When using the default `github.token`, the created/updated pull-request doesn't run associated workflows due to the restriction of the `github.token`. 
We need to use a personal access token override this restriction.