### PR TITLE
fix: revert to debian bullseye base due to missing libssl1.1 in bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:bullseye
 ARG TARGETARCH
 
 WORKDIR "/opt/drawio-desktop"


### PR DESCRIPTION
Revert the docker image base change from #76 due to missing package in the new version when this docker image is used on https://github.com/rlespinasse/drawio-export