### PR TITLE
ci: update before installing libxml2-utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test: cleanup build test-ci
 
 test-ci-setup:
 	@npm install bats
+	@sudo apt-get update
 	@sudo apt-get install -y libxml2-utils
 
 test-ci:


### PR DESCRIPTION
Fix build failure on the default branch