### PR TITLE
tests: make assertions not OS-dependent

### DIFF
--- a/tests/base.bats
+++ b/tests/base.bats
@@ -28,7 +28,8 @@ docker_test() {
   if [ -f "tests/expected/$output_file.log" ]; then
     diff -u --strip-trailing-cr "tests/expected/$output_file.log" "tests/output/$output_file-comp.log" >"tests/output/$output_file-diff.log"
   elif [ -f "tests/expected/uniq-$output_file.log" ]; then
-    diff -u --strip-trailing-cr "tests/expected/uniq-$output_file.log" <(LC_COLLATE=C sort -u "tests/output/$output_file-comp.log") >"tests/output/$output_file-diff.log"
+    # For now, I remove sqlite_persistent_shared_dictionary_store.cc from expected output since this line is inconsistent across runs
+    diff -u --strip-trailing-cr "tests/expected/uniq-$output_file.log" <(LC_COLLATE=C sort -u "tests/output/$output_file-comp.log" | grep -v "sqlite_persistent_shared_dictionary_store") >"tests/output/$output_file-diff.log"
   fi
   if [ -f "tests/output/$output_file-diff.log" ]; then
     [ "$(cat "tests/output/$output_file-diff.log")" = "" ]

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -24,7 +24,7 @@ docker_test() {
   if [ -f "tests/expected/$output_file.log" ]; then
     diff -u --strip-trailing-cr "tests/expected/$output_file.log" "tests/output/$output_file-comp.log" >"tests/output/$output_file-diff.log"
   elif [ -f "tests/expected/uniq-$output_file.log" ]; then
-    diff -u --strip-trailing-cr "tests/expected/uniq-$output_file.log" <(sort -u "tests/output/$output_file-comp.log") >"tests/output/$output_file-diff.log"
+    diff -u --strip-trailing-cr "tests/expected/uniq-$output_file.log" <(LC_COLLATE=C sort -u "tests/output/$output_file-comp.log") >"tests/output/$output_file-diff.log"
   fi
   if [ -f "tests/output/$output_file-diff.log"]; then
     [ "$(cat "tests/output/$output_file-diff.log")" = "" ]

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -26,7 +26,7 @@ docker_test() {
   elif [ -f "tests/expected/uniq-$output_file.log" ]; then
     diff -u --strip-trailing-cr "tests/expected/uniq-$output_file.log" <(LC_COLLATE=C sort -u "tests/output/$output_file-comp.log") >"tests/output/$output_file-diff.log"
   fi
-  if [ -f "tests/output/$output_file-diff.log"]; then
+  if [ -f "tests/output/$output_file-diff.log" ]; then
     [ "$(cat "tests/output/$output_file-diff.log")" = "" ]
   fi
 }

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -12,13 +12,17 @@ docker_test() {
   shift
 
   # Run command
-  echo docker container run -t $docker_opts -w /data -v $(pwd)/${data_folder:-}:/data ${DOCKER_IMAGE} "$@" >>tests/output/$output_file-command.log
-  run docker container run -t $docker_opts -w /data -v $(pwd)/${data_folder:-}:/data ${DOCKER_IMAGE} "$@"
+  # shellcheck disable=SC2086
+  echo docker container run -t $docker_opts -w /data -v "$(pwd)/${data_folder:-}":/data ${DOCKER_IMAGE} "$@" >>tests/output/$output_file-command.log
+  # shellcheck disable=SC2086
+  run docker container run -t $docker_opts -w /data -v "$(pwd)/${data_folder:-}":/data ${DOCKER_IMAGE} "$@"
 
   # Remove timed logging tags on electron logs by default.
+  # shellcheck disable=SC2154
   echo "$output" | tee "tests/output/$output_file.log" | sed 's#\[.*:.*/.*\..*:.*:.*\(.*\)\] ##' >"tests/output/$output_file-comp.log"
 
   # Test status
+  # shellcheck disable=SC2086
   [ "$status" -eq $status ]
   # Test output
   if [ -f "tests/expected/$output_file.log" ]; then

--- a/tests/error.bats
+++ b/tests/error.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# shellcheck source=/dev/null
 . tests/base.bats
 
 @test "Output an error on unknown file" {
@@ -7,5 +8,8 @@
 }
 
 @test "Output an error on unknown file with electron security warning" {
+  if [[ $(uname) == "Darwin" ]]; then
+    skip "Skipping test on macOS"
+  fi
   docker_test "-e ELECTRON_DISABLE_SECURITY_WARNINGS=false" 0 "output-unknown-file-electron-security-warning" "tests/data" -x unknown.drawio
 }

--- a/tests/error.bats
+++ b/tests/error.bats
@@ -8,8 +8,5 @@
 }
 
 @test "Output an error on unknown file with electron security warning" {
-  if [[ $(uname) == "Darwin" ]]; then
-    skip "Skipping test on macOS"
-  fi
   docker_test "-e ELECTRON_DISABLE_SECURITY_WARNINGS=false" 0 "output-unknown-file-electron-security-warning" "tests/data" -x unknown.drawio
 }

--- a/tests/expected/uniq-output-unknown-file-electron-security-warning.log
+++ b/tests/expected/uniq-output-unknown-file-electron-security-warning.log
@@ -2,7 +2,6 @@ Error: input file/directory not found
 Failed to call method: org.freedesktop.DBus.NameHasOwner: object_path= /org/freedesktop/DBus: unknown error type: 
 Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
 Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
-Failed to post task from operator()@net/extras/sqlite/sqlite_persistent_shared_dictionary_store.cc:263 to client_task_runner_.
 Floss manager service not available, cannot set Floss enable/disable.
 InitializeSandbox() called with multiple threads in process gpu-process.
 VizNullHypothesis is disabled (not a warning)

--- a/tests/export.bats
+++ b/tests/export.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# shellcheck source=/dev/null
 . tests/base.bats
 
 @test "Export a drawio file as pdf" {

--- a/tests/fonts.bats
+++ b/tests/fonts.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# shellcheck source=/dev/null
 . tests/base.bats
 
 @test "Fonts chinese" {

--- a/tests/issues.bats
+++ b/tests/issues.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# shellcheck source=/dev/null
 . tests/base.bats
 
 @test "Issue 20 : frame bug / svg :: theme=light" {

--- a/tests/timeout.bats
+++ b/tests/timeout.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# shellcheck source=/dev/null
 . tests/base.bats
 
 @test "Timeout for using create command" {


### PR DESCRIPTION
Between MacOS (like local machine) and Ubuntu (like GHA runner), the sort algorithm is not the same until we use `LC_COLLATE=C`.