### PR TITLE
Use fallback token for Docker workflow checkout

### DIFF
--- a/.github/workflows/docker-drawio-desktop-headless.yaml
+++ b/.github/workflows/docker-drawio-desktop-headless.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || github.token }}
 
       - uses: rlespinasse/github-slug-action@v5
 


### PR DESCRIPTION
## Summary
Updated the GitHub Actions checkout step in the Docker build workflow to use a fallback token when the custom `GH_TOKEN` secret is not available.

## Changes
- Modified the `token` input in the `actions/checkout@v4` step to use `secrets.GH_TOKEN || github.token` instead of just `secrets.GH_TOKEN`
- This ensures the workflow can proceed with the default `github.token` if the custom secret is not configured, improving workflow reliability

## Details
The change uses GitHub Actions' expression syntax to provide a fallback mechanism. If `secrets.GH_TOKEN` is not set or empty, the workflow will automatically use the built-in `github.token` instead of failing. This makes the workflow more resilient and reduces dependency on external secret configuration.

https://claude.ai/code/session_01KgnRUgxqamJ4GNYrQM2GQM