### PR TITLE
fix: silence Electron D-Bus/GPU noise at the source and stop flaky SVG autopatches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ apt-get clean
 
 # Deps
 apt-get update
-apt-get install -y xvfb wget libgbm1 libasound2
+apt-get install -y xvfb wget libgbm1 libasound2 dbus dbus-x11
 
 # Drawio Desktop
 DRAWIO_VERSION="30.2.6"

--- a/justfile
+++ b/justfile
@@ -101,8 +101,16 @@ patch-unwanted-security-warnings:
 [private]
 patch-tests:
   #!/usr/bin/env bash
-  mv tests/data/issue-20/frame-bug-dark.svg tests/expected/issue-20-frame-bug-dark.svg
-  mv tests/data/issue-20/frame-bug-light.svg tests/expected/issue-20-frame-bug-light.svg
+  normalize_svg_id() {
+    sed 's/ id="ge-svg-[^"]*"//; s/#ge-svg-[a-zA-Z0-9_-]*/dummy-id/g' "$1"
+  }
+  for theme in dark light; do
+    actual="tests/data/issue-20/frame-bug-${theme}.svg"
+    expected="tests/expected/issue-20-frame-bug-${theme}.svg"
+    if ! diff -q <(normalize_svg_id "$actual") <(normalize_svg_id "$expected") >/dev/null; then
+      mv "$actual" "$expected"
+    fi
+  done
   mv tests/data/fonts/chinese.png tests/expected/fonts-chinese.png
   git diff --exit-code tests/expected || \
     echo "Test files have been updated. Please check the changes before committing."

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -17,6 +17,15 @@ if [[ "${DRAWIO_DISABLE_UPDATE:?}" == "true" ]]; then
   cat "${DRAWIO_DESKTOP_SOURCE_FOLDER:?}/unwanted-update-logs.txt" >>"${DRAWIO_DESKTOP_SOURCE_FOLDER:?}/unwanted-lines.txt"
 fi
 
+# Start D-Bus buses
+# Electron probes both (Bluetooth/NameHasOwner/accessibility) even though they're unused
+# in a headless export. Best-effort: skip silently if we lack permission (e.g. non-root user).
+if mkdir -p /run/dbus 2>/dev/null; then
+  dbus-uuidgen --ensure >/dev/null 2>&1 || true
+  dbus-daemon --system --fork >/dev/null 2>&1 || true
+fi
+eval "$(dbus-launch --sh-syntax 2>/dev/null)" 2>/dev/null || true
+
 # Start Xvfb
 export DISPLAY="${XVFB_DISPLAY:?}"
 # shellcheck disable=SC2086

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -5,4 +5,6 @@ if [[ "${SCRIPT_DEBUG_MODE:-false}" == "true" ]]; then
   set -x
 fi
 
-"${DRAWIO_DESKTOP_EXECUTABLE_PATH:?}" "$@" --no-sandbox --disable-gpu
+"${DRAWIO_DESKTOP_EXECUTABLE_PATH:?}" "$@" --no-sandbox --disable-gpu \
+  --disable-features=VaapiVideoDecoder,VaapiVideoEncoder \
+  --disable-accelerated-video-decode --disable-accelerated-video-encode

--- a/src/unwanted-security-warnings.txt
+++ b/src/unwanted-security-warnings.txt
@@ -1,3 +1,4 @@
 Failed to call
 Failed to connect
+Failed to post
 Floss manager service

--- a/tests/expected/uniq-output-electron-security-warning.log
+++ b/tests/expected/uniq-output-electron-security-warning.log
@@ -1,5 +1,1 @@
-Failed to call method: org.freedesktop.DBus.NameHasOwner: object_path= /org/freedesktop/DBus: unknown error type: 
-Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
-Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
-Floss manager service not available, cannot set Floss enable/disable.
 file1.drawio -> file1.pdf

--- a/tests/expected/uniq-output-unknown-file-electron-security-warning.log
+++ b/tests/expected/uniq-output-unknown-file-electron-security-warning.log
@@ -1,5 +1,1 @@
 Error: input file/directory not found
-Failed to call method: org.freedesktop.DBus.NameHasOwner: object_path= /org/freedesktop/DBus: unknown error type: 
-Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
-Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
-Floss manager service not available, cannot set Floss enable/disable.


### PR DESCRIPTION
## Summary
- Start a session + system D-Bus in `entrypoint.sh` (best-effort, non-fatal for non-root) so Electron's D-Bus/Bluetooth probes succeed instead of erroring out. Falls back to the existing filter list when it can't start (e.g. non-root).
- Disable VAAPI video-accel backend (`--disable-features=VaapiVideoDecoder,VaapiVideoEncoder --disable-accelerated-video-decode --disable-accelerated-video-encode`) in `runner.sh`, since Chromium's `drmGetDevices2()` GPU probe is meaningless in a headless diagram-export container.
- Restore the `Failed to post … sqlite_persistent_shared_dictionary_store …` filter entry, dropped by a previous automated patch commit even though the underlying warning is still non-deterministic.
- Fix `patch-tests` in the `justfile` to normalize drawio's random per-export `ge-svg-*` id (the same way the bats test already does) before deciding whether the SVG expected fixtures changed — previously it blindly overwrote them every run, causing repeated no-op "apply automated patch after tests failure" commits.

## Context
Split out of the drawio-desktop version-bump PR for traceability: these are pre-existing, version-independent CI/runtime issues, not something introduced by the version update.

## Test plan
- [x] `just build && just test` — 13/13 bats tests pass, run twice to rule out flakiness
- [x] Verified via raw (unfiltered) container stderr diffing that D-Bus/Floss/VAAPI lines disappear at the source when running as root, and that the non-root path still falls back correctly to the filter