### PR TITLE
fix: silence Electron D-Bus and GPU-probe warnings at the source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ apt-get clean
 
 # Deps
 apt-get update
-apt-get install -y xvfb wget libgbm1 libasound2
+apt-get install -y xvfb wget libgbm1 libasound2 dbus dbus-x11
 
 # Drawio Desktop
 DRAWIO_VERSION="30.2.6"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -17,6 +17,15 @@ if [[ "${DRAWIO_DISABLE_UPDATE:?}" == "true" ]]; then
   cat "${DRAWIO_DESKTOP_SOURCE_FOLDER:?}/unwanted-update-logs.txt" >>"${DRAWIO_DESKTOP_SOURCE_FOLDER:?}/unwanted-lines.txt"
 fi
 
+# Start D-Bus buses
+# Electron probes both (Bluetooth/NameHasOwner/accessibility) even though they're unused
+# in a headless export. Best-effort: skip silently if we lack permission (e.g. non-root user).
+if mkdir -p /run/dbus 2>/dev/null; then
+  dbus-uuidgen --ensure >/dev/null 2>&1 || true
+  dbus-daemon --system --fork >/dev/null 2>&1 || true
+fi
+eval "$(dbus-launch --sh-syntax 2>/dev/null)" 2>/dev/null || true
+
 # Start Xvfb
 export DISPLAY="${XVFB_DISPLAY:?}"
 # shellcheck disable=SC2086

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -5,4 +5,6 @@ if [[ "${SCRIPT_DEBUG_MODE:-false}" == "true" ]]; then
   set -x
 fi
 
-"${DRAWIO_DESKTOP_EXECUTABLE_PATH:?}" "$@" --no-sandbox --disable-gpu
+"${DRAWIO_DESKTOP_EXECUTABLE_PATH:?}" "$@" --no-sandbox --disable-gpu \
+  --disable-features=VaapiVideoDecoder,VaapiVideoEncoder \
+  --disable-accelerated-video-decode --disable-accelerated-video-encode

--- a/tests/expected/uniq-output-electron-security-warning.log
+++ b/tests/expected/uniq-output-electron-security-warning.log
@@ -1,5 +1,1 @@
-Failed to call method: org.freedesktop.DBus.NameHasOwner: object_path= /org/freedesktop/DBus: unknown error type: 
-Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
-Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
-Floss manager service not available, cannot set Floss enable/disable.
 file1.drawio -> file1.pdf

--- a/tests/expected/uniq-output-unknown-file-electron-security-warning.log
+++ b/tests/expected/uniq-output-unknown-file-electron-security-warning.log
@@ -1,5 +1,1 @@
 Error: input file/directory not found
-Failed to call method: org.freedesktop.DBus.NameHasOwner: object_path= /org/freedesktop/DBus: unknown error type: 
-Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
-Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
-Floss manager service not available, cannot set Floss enable/disable.


### PR DESCRIPTION
## Summary
- Start a session + system D-Bus in `entrypoint.sh` (best-effort, non-fatal for non-root) so Electron's D-Bus/Bluetooth probes succeed instead of erroring out. Falls back to the existing `unwanted-security-warnings.txt` filter list when it can't start (e.g. non-root).
- Disable VAAPI video-accel backend (`--disable-features=VaapiVideoDecoder,VaapiVideoEncoder --disable-accelerated-video-decode --disable-accelerated-video-encode`) in `runner.sh`, since Chromium's `drmGetDevices2()` GPU probe is meaningless in a headless diagram-export container.
- Drop the now-dead `Failed to call` / `Failed to connect` / `Floss manager service` lines from the two raw (unfiltered) `uniq-output-*-electron-security-warning.log` fixtures, since they no longer appear in actual output when running as root.

## Context
Split out of the drawio-desktop version-bump PR for traceability: version-independent runtime noise, not something introduced by any version update. Split from #145, which bundled this with an unrelated flaky-test fix (see #147).

## Test plan
- [x] `just build && just test` — 12/13 bats tests pass in isolation; the one remaining failure ("Output an error on unknown file") is the unrelated, pre-existing `Failed to post … sqlite_persistent_shared_dictionary_store …` flake fixed in #147, not something this PR needs to touch
- [x] Verified via raw (unfiltered) container stderr diffing that D-Bus/Floss/VAAPI lines disappear at the source when running as root, and that the non-root path still falls back correctly to the filter