### PR TITLE
build: stop flaky test-fixture autopatch commits

### DIFF
--- a/justfile
+++ b/justfile
@@ -101,8 +101,16 @@ patch-unwanted-security-warnings:
 [private]
 patch-tests:
   #!/usr/bin/env bash
-  mv tests/data/issue-20/frame-bug-dark.svg tests/expected/issue-20-frame-bug-dark.svg
-  mv tests/data/issue-20/frame-bug-light.svg tests/expected/issue-20-frame-bug-light.svg
+  normalize_svg_id() {
+    sed 's/ id="ge-svg-[^"]*"//; s/#ge-svg-[a-zA-Z0-9_-]*/dummy-id/g' "$1"
+  }
+  for theme in dark light; do
+    actual="tests/data/issue-20/frame-bug-${theme}.svg"
+    expected="tests/expected/issue-20-frame-bug-${theme}.svg"
+    if ! diff -q <(normalize_svg_id "$actual") <(normalize_svg_id "$expected") >/dev/null; then
+      mv "$actual" "$expected"
+    fi
+  done
   mv tests/data/fonts/chinese.png tests/expected/fonts-chinese.png
   git diff --exit-code tests/expected || \
     echo "Test files have been updated. Please check the changes before committing."

--- a/src/unwanted-security-warnings.txt
+++ b/src/unwanted-security-warnings.txt
@@ -1,3 +1,4 @@
 Failed to call
 Failed to connect
+Failed to post
 Floss manager service


### PR DESCRIPTION
## Summary
- Fix `patch-tests` in the `justfile` to normalize drawio's random per-export `ge-svg-*` id (the same way the bats test already does) before deciding whether the SVG expected fixtures changed. Previously it blindly overwrote them every run, causing CI to repeatedly commit no-op "apply automated patch after tests failure" changes whenever any other test failed.
- Restore the `Failed to post … sqlite_persistent_shared_dictionary_store …` filter entry in `unwanted-security-warnings.txt`, which a prior automated patch commit dropped after a lucky run where this still-non-deterministic Chromium warning didn't fire.

## Context
Split out of the drawio-desktop version-bump PR for traceability: these are pre-existing, version-independent CI/test-infra issues, not something introduced by the version update. Split from #145, which bundled this with an unrelated D-Bus/GPU noise fix (see #146).

## Test plan
- [x] `just build && just test` — 13/13 bats tests pass, run twice to rule out flakiness
- [x] Manually verified `just patch-tests` no longer touches the SVG fixtures when only the random id differs (`git diff --stat` empty after running it)