### PR TITLE
feat: include upstream release notes in autoupdate PRs

### DIFF
--- a/.github/workflows/autoupdate-drawio-desktop.yaml
+++ b/.github/workflows/autoupdate-drawio-desktop.yaml
@@ -32,5 +32,10 @@ jobs:
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: "feat: update to drawio-desktop ${{ steps.autoupdate-drawio-desktop.outputs.release_version }}"
+          body: ${{ steps.autoupdate-drawio-desktop.outputs.release_notes }}
+          commit-message: |
+            feat: update to drawio-desktop ${{ steps.autoupdate-drawio-desktop.outputs.release_version }}
+
+            ${{ steps.autoupdate-drawio-desktop.outputs.release_notes }}
           branch: autoupdate-drawio-desktop
           token: ${{ secrets.GH_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -62,11 +62,41 @@ test-ci:
 [group('Maintenance mode')]
 autoupdate-drawio-desktop:
   #!/usr/bin/env bash
+  set -euo pipefail
+  CURRENT_VERSION=$(sed -n 's/.*DRAWIO_VERSION="\([^"]*\)".*/\1/p' Dockerfile | head -1)
   DRAWIO_DESKTOP_RELEASE=$(gh release list --repo jgraph/drawio-desktop | grep "Latest" | cut -f1)
   sed -i 's/DRAWIO_VERSION=.*/DRAWIO_VERSION="'$DRAWIO_DESKTOP_RELEASE'"/' Dockerfile
   sed -i 's/Draw\.io Desktop v.*/Draw.io Desktop v'$DRAWIO_DESKTOP_RELEASE'\]/' README.adoc
   if [ -n "${GITHUB_OUTPUT}" ]; then
     echo "release_version=$DRAWIO_DESKTOP_RELEASE" >> "${GITHUB_OUTPUT}"
+
+    RELEASE_NOTES=$(gh release view "v$DRAWIO_DESKTOP_RELEASE" --repo jgraph/drawio-desktop --json body -q .body)
+    CHANGELOG=$(curl -fsSL "https://raw.githubusercontent.com/jgraph/drawio/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog" || true)
+    if [ -n "$CHANGELOG" ] && grep -qE "^[0-9]{2}-[A-Z]{3}-[0-9]{4}: ${CURRENT_VERSION}$" <<< "$CHANGELOG"; then
+      CORE_CHANGES=$(awk -v old="$CURRENT_VERSION" '
+        /^[0-9]{2}-[A-Z]{3}-[0-9]{4}: / {
+          ver=$0; sub(/^[0-9]{2}-[A-Z]{3}-[0-9]{4}: /, "", ver)
+          if (ver == old) exit
+        }
+        { print }
+      ' <<< "$CHANGELOG")
+    else
+      CORE_CHANGES="See [draw.io core ChangeLog](https://github.com/jgraph/drawio/blob/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog)."
+    fi
+
+    {
+      echo "release_notes<<GH_RELEASE_NOTES_EOF"
+      echo "Updates \`drawio-desktop\` from \`$CURRENT_VERSION\` to \`$DRAWIO_DESKTOP_RELEASE\`."
+      echo
+      echo "### drawio-desktop release notes"
+      echo
+      echo "$RELEASE_NOTES"
+      echo
+      echo "### draw.io core ChangeLog ($CURRENT_VERSION -> $DRAWIO_DESKTOP_RELEASE)"
+      echo
+      echo "$CORE_CHANGES"
+      echo "GH_RELEASE_NOTES_EOF"
+    } >> "${GITHUB_OUTPUT}"
   fi
   echo "Updated to Draw.io Desktop version $DRAWIO_DESKTOP_RELEASE"
 


### PR DESCRIPTION
## Summary
- The `autoupdate-drawio-desktop` workflow only bumped `DRAWIO_VERSION` and opened a PR with just a title — no changelog context, unlike Dependabot PRs.
- drawio-desktop's own release notes point to `jgraph/drawio`'s ChangeLog as a bare link (a cumulative file, not a diff), so that pointer alone isn't useful.
- Now the recipe captures the pre-bump version, fetches the drawio-desktop release notes, and extracts the actual draw.io core ChangeLog entries between the old and new version into the PR body / commit message. Falls back to the pointer link if the upstream ChangeLog format ever changes.

## Test plan
- [x] Ran `just autoupdate-drawio-desktop` locally against a no-op case (already at latest) and a real bump case (31.1.8 -> 31.3.2) — verified extracted ChangeLog window and correct fallback behavior
- [x] Fixed a portability bug (`grep -oP` doesn't exist on BSD/macOS grep) found while testing locally
- [x] Verify the next scheduled `Autoupdate Drawio Desktop` run produces the expected PR body